### PR TITLE
About the meowing ban

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you have an issue with a staff action use the `🎟-talk-with-staff` option m
 
 ### 4. Expectation of Conduct & Discourse
 
-Debian Community aims to be a server for high-quality discourse and support, and thus we will emphasize that you only contribute or participate in our community servers with the expectation that low quality or low effort content is discouraged outside of our `memes` channel. For example, we are not going to demand that you only just post or start technical discussion, but posting something that does not make sense to post (for instance, posting animal noises, seeking to troll, incoherent spam, miscellaneous forms of brainrot, etc) is discouraged and moderation action make take place if a user continues to engage in it.
+Debian Community aims to be a server for high-quality discourse and support, and thus we will emphasize that you only contribute or participate in our community servers with the expectation that low quality or low effort content is discouraged outside of our `memes` channel. For example, we are not going to demand that you only just post or start technical discussion, but posting something that does not make sense to post (for instance, posting animal noises excessively, seeking to troll, incoherent spam, miscellaneous forms of brainrot, etc) is discouraged and moderation action make take place if a user continues to engage in it.
 
 We do require that all communication in this community be in English; we don't have the resources available to moderate non-English conversation.
 


### PR DESCRIPTION
I believe that meowing actually spurs conversation and for some people its how they first start talking in a channel. Banning meowing occasionally actually will hurt how the community functions as of current. We already don't have an issue with excessive meowing in general so banning all meowing doesn't really make sense.

(also plsplsplsplsplsplsplspls)